### PR TITLE
Support starting country in loadStories

### DIFF
--- a/lib/core/utils/app_router.dart
+++ b/lib/core/utils/app_router.dart
@@ -33,7 +33,10 @@ class AppRouter {
       GoRoute(
         path: AppConstants.ROUTE_HOME,
         name: 'home',
-        builder: (context, state) => const HomePage(),
+        builder: (context, state) {
+          final startingCountry = state.extra as String?;
+          return HomePage(startingCountry: startingCountry);
+        },
       ),
       GoRoute(
         path: '${AppConstants.ROUTE_READING}/:storyId',

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -24,10 +24,11 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     try {
       // Pour l'instant, on utilise des données mock
       final stories = _generateMockStories();
-      
-      // Simuler le pays de départ (pour l'instant Senegal)
-      const startingCountry = 'Senegal';
-      final unlockedCountries = [startingCountry];
+
+      // Utiliser le pays de départ fourni s'il existe
+      final startingCountry = event.startingCountry ?? '';
+      final unlockedCountries =
+          startingCountry.isNotEmpty ? [startingCountry] : [];
       
       emit(state.copyWith(
         stories: stories,

--- a/lib/features/home/presentation/bloc/home_event.dart
+++ b/lib/features/home/presentation/bloc/home_event.dart
@@ -2,7 +2,7 @@ part of 'home_bloc.dart';
 
 @freezed
 class HomeEvent with _$HomeEvent {
-  const factory HomeEvent.loadStories() = _LoadStories;
+  const factory HomeEvent.loadStories({String? startingCountry}) = _LoadStories;
   const factory HomeEvent.selectStory(Story story) = _SelectStory;
   const factory HomeEvent.clearSelection() = _ClearSelection;
   const factory HomeEvent.updateProgress(String storyId) = _UpdateProgress;

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -6,12 +6,14 @@ import 'package:kuma/features/home/presentation/widgets/story_bottom_sheet.dart'
 import 'package:kuma/shared/domain/entities/story.dart';
 
 class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+  final String? startingCountry;
+  const HomePage({super.key, this.startingCountry});
 
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => HomeBloc()..add(const HomeEvent.loadStories()),
+      create: (context) =>
+          HomeBloc()..add(HomeEvent.loadStories(startingCountry: startingCountry)),
       child: const HomeView(),
     );
   }

--- a/lib/features/home/presentation/widgets/africa_map_widget.dart
+++ b/lib/features/home/presentation/widgets/africa_map_widget.dart
@@ -91,7 +91,13 @@ class _AfricaMapWidgetState extends State<AfricaMapWidget>
                 const SizedBox(height: 16),
                 ElevatedButton(
                   onPressed: () {
-                    context.read<HomeBloc>().add(const HomeEvent.loadStories());
+                    final bloc = context.read<HomeBloc>();
+                    context.read<HomeBloc>().add(
+                          HomeEvent.loadStories(
+                              startingCountry: bloc.state.currentCountry.isNotEmpty
+                                  ? bloc.state.currentCountry
+                                  : null),
+                        );
                   },
                   child: const Text('Réessayer'),
                 ),

--- a/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -53,7 +53,10 @@ class _OnboardingViewState extends State<OnboardingView> {
           
           // Navigation vers l'app après completion
           if (state.currentPage > 6) {
-            context.go(AppConstants.ROUTE_HOME);
+            context.go(
+              AppConstants.ROUTE_HOME,
+              extra: state.startingCountry.isNotEmpty ? state.startingCountry : null,
+            );
           }
           
           // Affichage des erreurs
@@ -137,7 +140,10 @@ class _OnboardingViewState extends State<OnboardingView> {
               context.read<OnboardingBloc>().add(
                 const OnboardingEvent.skipOnboarding(),
               );
-              context.go(AppConstants.ROUTE_HOME);
+              context.go(
+                AppConstants.ROUTE_HOME,
+                extra: 'Senegal',
+              );
             },
             child: Text(
               'Passer',
@@ -179,7 +185,12 @@ class _OnboardingViewState extends State<OnboardingView> {
                 ? () {
                     if (state.currentPage == 6) {
                       bloc.add(const OnboardingEvent.completeOnboarding());
-                      context.go(AppConstants.ROUTE_HOME);
+                      context.go(
+                        AppConstants.ROUTE_HOME,
+                        extra: state.startingCountry.isNotEmpty
+                            ? state.startingCountry
+                            : null,
+                      );
                     } else {
                       bloc.add(const OnboardingEvent.nextPage());
                     }


### PR DESCRIPTION
## Summary
- allow `loadStories` event to carry an optional starting country
- initialize unlocked countries from provided starting country
- pass starting country from router and onboarding flow to the HomeBloc
- reload stories with current country when retrying

## Testing
- `flutter pub run build_runner build` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424e23d6a4833382f859547c318644